### PR TITLE
Fixes issue where Boost property of the TermQuery was formatted with a , (comma) instead of a . (dot)

### DIFF
--- a/ElasticSearch.Client/QueryDSL/Converters/Filter/TermFilterConvert.cs
+++ b/ElasticSearch.Client/QueryDSL/Converters/Filter/TermFilterConvert.cs
@@ -8,7 +8,15 @@ namespace ElasticSearch.Client.QueryDSL
         {
             TermFilter term = (TermFilter)value;
             if (term != null)
-                writer.WriteRawValue(string.Format("{{term: {{ \"{0}\" : \"{1}\"}} }}", term.Field, term.Value));
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("term");
+                writer.WriteStartObject();
+                writer.WritePropertyName(term.Field);
+                writer.WriteValue(term.Value);
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+            }
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/ElasticSearch.Client/QueryDSL/Converters/Query/TermQueryConvert.cs
+++ b/ElasticSearch.Client/QueryDSL/Converters/Query/TermQueryConvert.cs
@@ -8,8 +8,35 @@ namespace ElasticSearch.Client.QueryDSL
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			TermQuery term = (TermQuery)value;
-			if (term != null)
-				writer.WriteRawValue(string.Format("{{term: {{ \"{0}\" : {{ \"term\" : \"{1}\", \"boost\":{2} }}}} }}", term.Field, term.Value, term.Boost));
+            if (term != null)
+            {
+                /* Writes the following json
+                 *  {
+                 *      "term":
+                 *      {
+                 *          "term.Field": 
+                 *          {
+                 *              "term": "term.Value",
+                 *              "boost": term.Boost
+                 *          }
+                 *      }
+                 *  }
+                 */
+
+                writer.WriteStartObject();
+                writer.WritePropertyName("term");
+                writer.WriteStartObject();
+                writer.WritePropertyName(term.Field);
+                writer.WriteStartObject();
+                writer.WritePropertyName("term");
+                writer.WriteValue(term.Value);
+                writer.WritePropertyName("boost");
+                writer.WriteValue(term.Boost);
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+            }
+            //writer.WriteRawValue(string.Format("{{term: {{ \"{0}\" : {{ \"term\" : \"{1}\", \"boost\":{2} }}}} }}", term.Field, term.Value, term.Boost));
 		}
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/ElasticSearch.Client/QueryDSL/Query/CustomFiltersScoreQuery.cs
+++ b/ElasticSearch.Client/QueryDSL/Query/CustomFiltersScoreQuery.cs
@@ -3,29 +3,63 @@ using Newtonsoft.Json;
 
 namespace ElasticSearch.Client.QueryDSL
 {
-	/// <summary>
-	/// A custom_filters_score query allows to execute a query, and if the hit matches a provided filter (ordered), use either a boost or a script associated with it to compute the score
-	/// </summary>
-	[JsonConverter(typeof(CustomFiltersScoreQueryConverterer))]
-	[JsonObject("custom_filters_score")]
-	public class CustomFiltersScoreQuery:IQuery
-	{
-		public IQuery Query;
-		public List<IFilter> Filters;
-		/// <summary>
-		/// A score_mode can be defined to control how multiple matching filters control the score. By default, it is set to first which means the first matching filter will control the score of the result. It can also be set to max/total/avg which will aggregate the result from all matching filters based on the aggregation type.
-		/// </summary>
-		public string ScoreMode;
+    /// <summary>
+    /// A custom_filters_score query allows to execute a query, and if the hit matches a provided filter (ordered), use either a boost or a script associated with it to compute the score
+    /// </summary>
+    [JsonConverter(typeof(CustomFiltersScoreQueryConverterer))]
+    [JsonObject("custom_filters_score")]
+    public class CustomFiltersScoreQuery: IQuery
+    {
+        public IQuery Query;
+        public IDictionary<IFilter, double> Filters;
+        /// <summary>
+        /// A score_mode can be defined to control how multiple matching filters control the score. By default, it is set to first which means the first matching filter will control the score of the result. It can also be set to max/total/avg which will aggregate the result from all matching filters based on the aggregation type.
+        /// </summary>
+        public ScoreModeEnum ScoreMode = ScoreModeEnum.NotSet;
 
-		/// <summary>
-		/// A script can be used instead of boost for more complex score calculations. With optional params and lang (on the same level as query and filters).
-		/// </summary>
-		public string Script;
+        /// <summary>
+        /// A script can be used instead of boost for more complex score calculations. With optional params and lang (on the same level as query and filters).
+        /// </summary>
+        public string Script;
 
-		public CustomFiltersScoreQuery(IQuery query,List<IFilter> filters)
-		{
-			Query = query;
-			Filters = filters;
-		}
-	}
+        public CustomFiltersScoreQuery(IQuery query, List<IFilter> filters)
+        {
+            Query = query;
+            foreach (var filter in filters)
+            {
+                Filters.Add(filter, 1);
+            }
+        }
+
+        public CustomFiltersScoreQuery(IQuery query, IDictionary<IFilter, double> boostedFilters)
+        {
+            Filters = boostedFilters;
+        }
+
+        public CustomFiltersScoreQuery AddBoostedFilter(IFilter filter, double boost)
+        {
+            Filters.Add(filter, boost);
+            return this;
+        }
+
+        public CustomFiltersScoreQuery SetFilterBoost(IFilter filter, double boost)
+        {
+            if (Filters.ContainsKey(filter))
+            {
+                Filters[filter] = boost;
+            }
+            return this;
+        }
+
+        public enum ScoreModeEnum
+        {
+            First,
+            Min,
+            Max,
+            Total,
+            Avg,
+            Multiply,
+            NotSet
+        }
+    }
 }

--- a/ElasticSearch.Client/QueryDSL/Query/CustomFiltersScoreQuery.cs
+++ b/ElasticSearch.Client/QueryDSL/Query/CustomFiltersScoreQuery.cs
@@ -11,7 +11,7 @@ namespace ElasticSearch.Client.QueryDSL
     public class CustomFiltersScoreQuery: IQuery
     {
         public IQuery Query;
-        public IDictionary<IFilter, double> Filters;
+        public IDictionary<IFilter, double> Filters = new Dictionary<IFilter, double>();
         /// <summary>
         /// A score_mode can be defined to control how multiple matching filters control the score. By default, it is set to first which means the first matching filter will control the score of the result. It can also be set to max/total/avg which will aggregate the result from all matching filters based on the aggregation type.
         /// </summary>
@@ -33,6 +33,7 @@ namespace ElasticSearch.Client.QueryDSL
 
         public CustomFiltersScoreQuery(IQuery query, IDictionary<IFilter, double> boostedFilters)
         {
+            Query = query;
             Filters = boostedFilters;
         }
 

--- a/ElasticSearch.Client/QueryDSL/Query/CustomFiltersScoreQueryConverterer.cs
+++ b/ElasticSearch.Client/QueryDSL/Query/CustomFiltersScoreQueryConverterer.cs
@@ -3,46 +3,57 @@ using Newtonsoft.Json;
 
 namespace ElasticSearch.Client.QueryDSL
 {
-	internal class CustomFiltersScoreQueryConverterer:JsonConverter
-	{
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-		{
-			CustomFiltersScoreQuery term = (CustomFiltersScoreQuery)value;
-			if (term != null)
-			{
-				writer.WriteStartObject();
-				writer.WritePropertyName("custom_filters_score");
-				writer.WriteStartObject();
-				writer.WritePropertyName("query");
-				serializer.Serialize(writer,term.Query);
-				writer.WritePropertyName("filters");
+    internal class CustomFiltersScoreQueryConverterer: JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            CustomFiltersScoreQuery term = (CustomFiltersScoreQuery)value;
+            if (term != null)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("custom_filters_score");
+                writer.WriteStartObject();
+                writer.WritePropertyName("query");
+                serializer.Serialize(writer, term.Query);
+                writer.WritePropertyName("filters");
 
-				writer.WriteStartArray();
-				foreach (var filter in term.Filters)
-				{
-					serializer.Serialize(writer,filter);
-				}
-				writer.WriteEndArray();
+                writer.WriteStartArray();
+                foreach (var filter in term.Filters)
+                {
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("filter");
+                    serializer.Serialize(writer, filter.Key);
+                    writer.WritePropertyName("boost");
+                    writer.WriteValue(filter.Value);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
 
-				writer.WritePropertyName("score_mode");
-				writer.WriteValue(term.ScoreMode);
+                if (term.ScoreMode != CustomFiltersScoreQuery.ScoreModeEnum.NotSet)
+                {
+                    writer.WritePropertyName("score_mode");
+                    writer.WriteValue(term.ScoreMode.ToString());
+                }
 
-				writer.WritePropertyName("script");
-				writer.WriteValue(term.Script);
+                if (!string.IsNullOrEmpty(term.Script))
+                {
+                    writer.WritePropertyName("script");
+                    writer.WriteValue(term.Script);
+                }
 
-				writer.WriteEndObject();
-				writer.WriteEndObject();
-			}
-		}
+                writer.WriteEndObject();
+                writer.WriteEndObject();
+            }
+        }
 
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-		{
-			throw new NotImplementedException();
-		}
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
 
-		public override bool CanConvert(Type objectType)
-		{
-			return typeof(CustomFiltersScoreQuery).IsAssignableFrom(objectType);
-		}
-	}
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(CustomFiltersScoreQuery).IsAssignableFrom(objectType);
+        }
+    }
 }


### PR DESCRIPTION
It seems the string.Format was taking into account the culture and a
value with a dot for the Boost property was transformed into a comma in
certain culture.
The code was changed to use the JsonWriter methods in order to create
the JSON object
